### PR TITLE
Added requires in index.js for wavesurfer.js library.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,12 @@ import { Provider } from 'react-redux'
 import { createStore } from 'redux'
 import rootReducer from './reducers'
 
+// NOTE: These must come after your imports.
+require('wavesurfer.js');
+require('wavesurfer.js/dist/plugin/wavesurfer.timeline.min.js');
+require('wavesurfer.js/dist/plugin/wavesurfer.regions.min.js');
+require('wavesurfer.js/dist/plugin/wavesurfer.minimap.min.js');
+
 const store = createStore(rootReducer, window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
 )
 


### PR DESCRIPTION
Off of what you have in your `master` branch, which looks to be post `eject`ing, this addition to your `index.js` should get wavesurfer to work now when you push to Heroku.

Local development with `create-react-app` worked fine without this because it automatically looked for them in your `node_modules` but when building/deploying, it no longer has the ability to look locally. I didn't catch this difference when looking at their docs and didn't realize that this is why they had that code in their instructions. I had to look at their [example project](https://github.com/mspae/react-wavesurfer/blob/master/example/index.jsx) to figure this out.